### PR TITLE
fix order of parameters in labelling default namespace commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Verify Istio installation using `kubectl get po -n istio-system`, you should see
 
 ```bash
 # label default namespace
-kubectl label default ns istio-injection=enabled --overwrite
+kubectl label ns default istio-injection=enabled --overwrite
 
 # delete existing pods so that Istio can inject sidecar
 kubectl delete po --all
@@ -265,7 +265,7 @@ To undo changes made in Kubernetes cluster, execute following CLI commands in te
 
 ```bash
 # remove label from default namespace
-kubectl label default ns istio-injection-
+kubectl label ns default istio-injection-
 
 # install and configure Istio gateway
 kubectl delete -f istio/gateway.yaml


### PR DESCRIPTION
*Description of changes:*

Provided kubectl commands to label the default namespace will result in an error. This is to correct the order of the parameters so that the commands work.

Tested on kubectl version 1.21.0


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
