### PR TITLE
added note on SNI gotcha when Istio Gateway has hosts

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,8 @@ spec:
 ```
 You will notice that I am using the Kubernetes secret named `tls-secret` as `credentialName` which we generated earlier. The secret contains openssl generated key/cert. Gateway `yelb-gateway` is listening on port `443` for encrypted traffic.
 
+Note on SNI: ALB Ingress will not send an SNI (server name indication) to Istio so `hosts` must be `"*"` otherwise Istio will attempt to match it and result in 404.
+
 ### Configure ALB Ingress Resource
 
 Istio can not use the TLS certificate in ACM directly. However, I will use ACM certificates with AWS Application Load Balancer to terminate HTTPS traffic and then forward to Istio ingress gateway for further processing.


### PR DESCRIPTION
Description of changes: I found this example very useful but I was building a setup with multiple Istio Gateways configuring the same istio-proxy and matching the gateway by host worked initially until I switched to using TLS to prepare it for production and everything crumbled. Many nights later reading blogs and documentations it became clear that SNI forward was my issue. ALB Ingress does not forward the  SNI to Istio so host-based matching cannot be used to select the gateway. So I think adding this note somewhere in here will help others.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
